### PR TITLE
Changed socket read length

### DIFF
--- a/SimpleXmlRpc.php
+++ b/SimpleXmlRpc.php
@@ -259,15 +259,15 @@ class ServerProxy
             $response_header[] = array_map("trim", explode(":", $line, 2));
         }
 
+        // parse header
+        $this->_last_header = ServerProxy::_parse_header($response_header);
+
         // read message body
         $content = "";
-        while (!feof($sock)) {
+        while (strlen($content) < $this->_last_header['Content-Length']) {
             $content .= fgets($sock);
         }
         fclose($sock);
-
-        // parse header
-        $this->_last_header = ServerProxy::_parse_header($response_header);
 
         // gzip encoding
         if (isset($this->_last_header["Content-Encoding"])


### PR DESCRIPTION
While working with unix sockets I encountered an issue where `feof` did not detect properly end of communication so I had to limit reads to content length given in HTTP header.
This may be an issue in service I was communicating with [supervisord](http://supervisord.org/)